### PR TITLE
Changed the interface of snappable modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 ### Changed
 
 - Swift 5.3 support [#8](https://github.com/hugehoge/Snappable/pull/8), [#9](https://github.com/hugehoge/Snappable/pull/9)
+- Changed the interface of snappable modifier [#10](https://github.com/hugehoge/Snappable/pull/10)
 
 ### Fixed
 

--- a/Example/CarouselExample/CarouselExample/Components/CarouselView.swift
+++ b/Example/CarouselExample/CarouselExample/Components/CarouselView.swift
@@ -22,7 +22,7 @@ struct CarouselView: View {
         }
       }
     }
-    .snappable(snapAlignment, mode: snapMode)
+    .snappable(alignment: snapAlignment, mode: snapMode)
   }
 
   private func color(_ index: Int) -> Color {

--- a/Example/CarouselExample/CarouselExample/Components/MultiWidthCarouselView.swift
+++ b/Example/CarouselExample/CarouselExample/Components/MultiWidthCarouselView.swift
@@ -22,7 +22,7 @@ struct MultiWidthCarouselView: View {
         }
       }
     }
-    .snappable(snapAlignment, mode: snapMode)
+    .snappable(alignment: snapAlignment, mode: snapMode)
   }
 
   private func color(_ index: Int) -> Color {

--- a/Example/VerticalExample/VerticalExample/ContentView.swift
+++ b/Example/VerticalExample/VerticalExample/ContentView.swift
@@ -16,7 +16,10 @@ struct ContentView: View {
         }
       }
     }
-    .snappable(.bottom, mode: .afterScrolling(decelerationRate: .normal))
+    .snappable(
+      alignment: .bottom,
+      mode: .afterScrolling(decelerationRate: .normal)
+    )
   }
 
   private func color(_ index: Int) -> Color {

--- a/Sources/Public/ScrollView+SnappableModifier.swift
+++ b/Sources/Public/ScrollView+SnappableModifier.swift
@@ -8,7 +8,7 @@ public extension ScrollView {
   /// - Returns: A ScrollView, with the snapping behavior set.
   func snappable(
     _ alignment: SnapAlignment = .center,
-    mode: SnapMode = .afterScrolling
+    mode: SnapMode = .immediately
   ) -> some View {
     self.modifier(SnappableModifier(alignment: alignment, mode: mode))
   }

--- a/Sources/Public/ScrollView+SnappableModifier.swift
+++ b/Sources/Public/ScrollView+SnappableModifier.swift
@@ -7,7 +7,7 @@ public extension ScrollView {
   ///   - mode: The mode by when ScrollView snaps the items.
   /// - Returns: A ScrollView, with the snapping behavior set.
   func snappable(
-    _ alignment: SnapAlignment = .center,
+    alignment: SnapAlignment = .center,
     mode: SnapMode = .immediately
   ) -> some View {
     self.modifier(SnappableModifier(alignment: alignment, mode: mode))


### PR DESCRIPTION
- The default value of `snapMode` parameter has been changed from `.afterScroll` to `.immediately`
- Make `alignment:` label explicit