### PR TITLE
Fixed the sample codes in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 ### Changed
 
 - Swift 5.3 support [#8](https://github.com/hugehoge/Snappable/pull/8), [#9](https://github.com/hugehoge/Snappable/pull/9)
-- Changed the interface of snappable modifier [#10](https://github.com/hugehoge/Snappable/pull/10)
+- Changed the interface of snappable modifier [#10](https://github.com/hugehoge/Snappable/pull/10), [#12](https://github.com/hugehoge/Snappable/pull/12)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ struct ContentView: View {
 The snap anchor point can be set as an option.
 
 ```swift
-.snappable(.leading)
+.snappable(alignment: .leading)
 ```
 
-Available parameters are below:
+Available alignment parameters are below:
 
 - `.top`
 - `.leading`
@@ -89,9 +89,9 @@ You can determine the snap timing after the end of the drag with following param
 Both parameters are set together with scrolling deceleration rate.
 
 ```swift
-.snappable(.center, mode: .afterScolling(decelerationRate: .fast))
+.snappable(alignment: .center, mode: .afterScolling(decelerationRate: .fast))
 ```
 
 ```swift
-.snappable(.center, mode: .immediately(decelerationRate: .normal, withFlick: false))
+.snappable(alignment: .center, mode: .immediately(decelerationRate: .normal, withFlick: false))
 ```


### PR DESCRIPTION
Fixed the sample codes in README.md due to the interface changes of `.snappable` modifier (#10).